### PR TITLE
Runtime update

### DIFF
--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -3,7 +3,6 @@
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
     "runtime-version": "5.9",
-    "branch": "stable",
     "command": "Fritzing",
     "rename-desktop-file": "fritzing.desktop",
     "rename-appdata-file": "fritzing.appdata.xml",

--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -2,7 +2,7 @@
     "id": "org.fritzing.Fritzing",
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.9",
+    "runtime-version": "5.12",
     "command": "Fritzing",
     "rename-desktop-file": "fritzing.desktop",
     "rename-appdata-file": "fritzing.appdata.xml",
@@ -45,8 +45,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libgit2/libgit2/archive/v0.24.0.tar.gz",
-                    "sha256": "e2913862fd3bfdc7b75becb7603d4972ba57eafc1dd99d23127e6deca8aaf57d"
+                    "url": "https://github.com/libgit2/libgit2/archive/v0.27.7.tar.gz",
+                    "sha256": "1a5435a483759b1cd96feb12b11abb5231b0688016db506ce5947178f6ba2531"
                 }
             ]
         },


### PR DESCRIPTION
New KDE platform includes LTS Qt 5.12 and is based on FDo 18.08.