### PR TITLE
Patch the .desktop file to add StartupWMClass

### DIFF
--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -72,7 +72,8 @@
                 {
                     "type": "patch",
                     "paths": [
-                        "patches/fritzing-appdata-screenshots.patch"
+                        "patches/fritzing-appdata-screenshots.patch",
+                        "patches/add-wm-class.patch"
                     ]
                 },
                 {

--- a/patches/add-wm-class.patch
+++ b/patches/add-wm-class.patch
@@ -1,0 +1,21 @@
+From d49b6f83b3b6224c45562de15c9492a4546c414c Mon Sep 17 00:00:00 2001
+From: Stan Janssen <stan@finetuned.nl>
+Date: Wed, 15 Dec 2021 09:21:42 +0100
+Subject: [PATCH] Add StartupWMClass to .desktop file
+
+---
+ org.fritzing.Fritzing.desktop | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/org.fritzing.Fritzing.desktop b/org.fritzing.Fritzing.desktop
+index e7899f90..56ab020d 100644
+--- a/org.fritzing.Fritzing.desktop
++++ b/org.fritzing.Fritzing.desktop
+@@ -14,3 +14,4 @@ Categories=Development;IDE;Electronics;
+ Keywords=EDA;PCB;prototype;circuit;schematic;
+ StartupNotify=true
+ MimeType=application/x-fritzing-fz;application/x-fritzing-fzz;application/x-fritzing-fzp;application/x-fritzing-fzpz;application/x-fritzing-fzb;application/x-fritzing-fzbz;application/x-fritzing-fzm;
++StartupWMClass=Fritzing
+-- 
+2.25.1
+


### PR DESCRIPTION
This prevents the Dock icon from being duplicated on elemenatryOS

Please see https://github.com/elementary/dock/issues/64 for more information