### PR TITLE
Update to 0.9.10

### DIFF
--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -2,11 +2,11 @@
     "id": "org.fritzing.Fritzing",
     "runtime": "org.kde.Platform",
     "sdk": "org.kde.Sdk",
-    "runtime-version": "5.15-21.08",
+    "runtime-version": "5.15-22.08",
     "command": "Fritzing",
     "rename-icon": "fritzing",
     "finish-args": [
-        "--socket=x11", "--share=ipc",
+        "--socket=fallback-x11", "--share=ipc",
         "--socket=wayland",
         "--device=dri",
         "--socket=pulseaudio",
@@ -32,19 +32,55 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz",
-                    "sha256": "bd0df411efd9a585e5a2212275f8762079fed8842264954675a4fddc46cfcf60"
+                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz",
+                    "sha256": "205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6"
                 }
             ]
         },
         {
-            "name": "libgit2",
+            "name": "quazip",
             "buildsystem": "cmake-ninja",
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/libgit2/libgit2/archive/v0.27.7.tar.gz",
-                    "sha256": "1a5435a483759b1cd96feb12b11abb5231b0688016db506ce5947178f6ba2531"
+                    "url": "https://github.com/stachenov/quazip/archive/refs/tags/v1.3.tar.gz",
+                    "sha256": "c1239559cd6860cab80a0fd81f4204e606f9324f702dab6166b0960676ee1754"
+                }
+            ]
+        },
+        {
+            "name" : "libssh2",
+            "buildsystem" : "cmake-ninja",
+            "config-opts" : [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib",
+                "-DBUILD_SHARED_LIBS:BOOL=ON"
+            ],
+            "cleanup" : [
+                "/share/doc"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/libssh2/libssh2.git",
+                    "tag" : "libssh2-1.10.0"
+                }
+            ]
+        },
+        {
+            "name" : "libgit2",
+            "buildsystem" : "cmake-ninja",
+            "config-opts" : [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DBUILD_SHARED_LIBS:BOOL=ON",
+                "-DUSE_SSH:BOOL=ON",
+                "-DUSE_THREADS:BOOL=ON"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/libgit2/libgit2.git",
+                    "tag" : "v1.4.4"
                 }
             ]
         },
@@ -65,21 +101,21 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/fritzing/fritzing-app.git",
-                    "tag": "0.9.6",
-                    "commit": "8a1e0682d7846f6384ae45373961ed693b4c55d2"
+                    "url": "https://github.com/hsoj/fritzing-app.git",
+                    "commit": "b6fff32286449c4f1095557db1879cb1e4a62ec9"
                 },
                 {
                     "type": "patch",
                     "paths": [
                         "patches/fritzing-appdata-screenshots.patch",
-                        "patches/add-wm-class.patch"
+                        "patches/add-wm-class.patch",
+                        "patches/fix-quazipdetect.patch"
                     ]
                 },
                 {
                     "type": "git",
                     "url": "https://github.com/fritzing/fritzing-parts.git",
-                    "commit": "b82c8c3abd9bca5d30a4d0c28fb4327ac38cf511",
+                    "tag": "0.9.10",
                     "dest": "parts"
                 },
                 {

--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -101,8 +101,8 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://github.com/hsoj/fritzing-app.git",
-                    "commit": "b6fff32286449c4f1095557db1879cb1e4a62ec9"
+                    "url": "https://github.com/fritzing/fritzing-app.git",
+                    "commit": "14c1ae4a9af7c5f4f1c7438f8cda7750c09e2175"
                 },
                 {
                     "type": "patch",

--- a/patches/fix-quazipdetect.patch
+++ b/patches/fix-quazipdetect.patch
@@ -1,0 +1,71 @@
+diff --git a/pri/quazipdetect.pri b/pri/quazipdetect.pri
+index 8b23f4dc..e3cab4be 100644
+--- a/pri/quazipdetect.pri
++++ b/pri/quazipdetect.pri
+@@ -2,56 +2,14 @@
+ 
+ message("Using fritzing quazip detect script.")
+ 
+-exists($$absolute_path($$PWD/../../quazip_qt5)) {
+-        QUAZIPPATH = $$absolute_path($$PWD/../../quazip_qt5)
+-        message("found quazip in $${QUAZIPPATH}")
+-    } else {
+-        error("quazip could not be found.")
+-    }
++QUAZIP_PKG_NAME = quazip1-qt$${QT_MAJOR_VERSION}
++QUAZIP_INCLUDEPATH += $$system(pkg-config --cflags-only-I "$${QUAZIP_PKG_NAME}" | sed -e 's/-I//g')
++QUAZIP_LIBS += $$system(pkg-config --libs "$${QUAZIP_PKG_NAME}")
++QUAZIP_LIBS ~= s/-l[^ ]*Core//g # remove -lQt${VER}Core
+ 
+-message("including $$absolute_path($${QUAZIPPATH}/include/quazip)")
++message(Compiling against found libquazip ($${QUAZIP_LIBS}).)
+ 
+-unix:!macx {
+-    message("including quazip library on linux")
+-    INCLUDEPATH += $$absolute_path($${QUAZIPPATH}/include/quazip)
+-    LIBS += -L$$absolute_path($${QUAZIPPATH}/lib) -lquazip1-qt5
+-    QMAKE_RPATHDIR += $$absolute_path($${QUAZIPPATH}/lib)
+-    LIBS += -lz
+-}
+-
+-macx {
+-    message("including quazip library on mac os")
+-    INCLUDEPATH += $$absolute_path($${QUAZIPPATH}/include/quazip)
+-    LIBS += -L$$absolute_path($${QUAZIPPATH}/lib) -lquazip1-qt5
+-    QMAKE_RPATHDIR += $$absolute_path($${QUAZIPPATH}/lib)
+-    LIBS += -lz
+-}
+-
+-win32 {
+-
+-    message("including quazip library on windows")
+-
+-    QUAZIPINCLUDE = $$absolute_path($${QUAZIPPATH}/include/quazip)
+-    exists($$QUAZIPINCLUDE/quazip.h) {
+-        message("found quazip include path at $$QUAZIPINCLUDE")
+-    } else {
+-        message("Fritzing requires quazip")
+-        error("quazip include path not found in $$QUAZIPINCLUDE")
+-    }
+-
+-    INCLUDEPATH += $$QUAZIPINCLUDE
+-
+-    contains(QMAKE_TARGET.arch, x86_64) {
+-        QUAZIPLIB = $$absolute_path($$QUAZIPPATH/build64/Release)
+-    } else {
+-        QUAZIPLIB = $$absolute_path($$QUAZIPPATH/build32/Release)
+-    }
+-
+-    exists($$QUAZIPLIB/quazip1-qt5.lib) {
+-        message("found quazip library in $$QUAZIPLIB")
+-    } else {
+-        error("quazip library not found in $$QUAZIPLIB")
+-    }
+-
+-    LIBS += -L$$QUAZIPLIB -lquazip1-qt5
+-}
+\ No newline at end of file
++INCLUDEPATH += \
++    $${QUAZIP_INCLUDEPATH}
++LIBS += \
++    $${QUAZIP_LIBS}


### PR DESCRIPTION
Hi!

I also updated the dependencies and the runtime.

However the source code of Fritzing is no longer updated at [https://github.com/fritzing/fritzing-app](https://github.com/fritzing/fritzing-app) but rather on one of the developer personal repository at [https://github.com/hsoj/fritzing-app](https://github.com/hsoj/fritzing-app). I couldn't find any explanation from the team regarding that change, maybe it could be worth to ask the developers before merging this.
It seems to be the code used to make the official builds as every fixed bugs are referenced from a commit of the new repo (for instance [https://github.com/fritzing/fritzing-app/issues/3943](https://github.com/fritzing/fritzing-app/issues/3943) ).