### PR TITLE
update boost url

### DIFF
--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -32,7 +32,7 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://boostorg.jfrog.io/artifactory/main/release/1.66.0/source/boost_1_66_0.tar.gz",
+                    "url": "https://archives.boost.io/release/1.66.0/source/boost_1_66_0.tar.gz",
                     "sha256": "bd0df411efd9a585e5a2212275f8762079fed8842264954675a4fddc46cfcf60"
                 }
             ]


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
