### PR TITLE
Mark Fritzing as EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "publish-delay-hours": 3
+  "publish-delay-hours": 3,
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
This application relies on an outdated runtime that was marked as end-of-life (EOL) two years ago.

https://github.com/flathub/org.fritzing.Fritzing/issues/21